### PR TITLE
update getDownloadsDirectory of DownloadsPathProviderPlugin.m

### DIFF
--- a/ios/Classes/DownloadsPathProviderPlugin.m
+++ b/ios/Classes/DownloadsPathProviderPlugin.m
@@ -18,13 +18,8 @@
 }
 
 - (NSString*)getDownloadsDirectory {
-  NSFileManager* manager = [NSFileManager defaultManager];
-  NSArray<NSURL*>* urls = [manager URLsForDirectory:NSDownloadsDirectory inDomains:NSUserDomainMask];
-  if ([urls count] >= 1) {
-    NSURL* url = urls[0];
-    return url.absoluteString;
-  }
-  return nil;
+  NSArray* paths = NSSearchPathForDirectoriesInDomains(NSDownloadsDirectory, NSUserDomainMask, YES);
+  return paths.firstObject;
 }
 
 @end


### PR DESCRIPTION
getDownloadsDirectory was getting error when create directory. 
<pre>
[VERBOSE-2:ui_dart_state.cc(148)] Unhandled Exception: FileSystemException: Creation failed, path = 'file:///Users/heber/Library/Developer/CoreSimulator/Devices/4E392518-64B1-4984-A650-D69B739B4093/data/Containers/Data/Application/AD2A8648-F2A8-480D-8B16-ECC30EB75BFE/Downloads/' (OS Error: No such file or directory, errno = 2)
#0      _Directory.create.<anonymous closure> (dart:io/directory_impl.dart:122:11)
#1      _rootRunUnary (dart:async/zone.dart:1132:38)
#2      _CustomZone.runUnary (dart:async/zone.dart:1029:19)
#3      _FutureListener.handleValue (dart:async/future_impl.dart:126:18)
#4      Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:639:45)
#5      Future._propagateToListeners (dart:async/future_impl.dart:668:32)
#6      Future._completeWithValue (dart:async/future_impl.dart:483:5)
#7      Future._asyncComplete.<anonymous closure> (dart:async/future_impl.dart:513:7)
#8      _rootRun (dart:async/zone.dart:1124:13)
#9      _CustomZone.run (dart:async/zone.dart<…>
</pre>

Your code was returning this string:
file:///Users/heber/Library/Developer/CoreSimulator/Devices/4E392518-64B1-4984-A650-D69B739B4093/data/Containers/Data/Application/AD2A8648-F2A8-480D-8B16-ECC30EB75BFE/Downloads/

I suppose that start path with "file://..." was getting error. After my modification the method are returning this: 
/Users/heber/Library/Developer/CoreSimulator/Devices/4E392518-64B1-4984-A650-D69B739B4093/data/Containers/Data/Application/757F0A32-E882-4C7E-8D82-80A5943CD786/Downloads
My solution works fine in IOS 12.2.